### PR TITLE
docs: fix alt tag for facebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <img align="left" alt="Ali's LinkedIn" width="22px" src="https://raw.githubusercontent.com/peterthehan/peterthehan/master/assets/linkedin.svg" />
 </a>
 <a href="https://facebook.com/nowraiz">
-  <img align="left" alt="Ali's Discord" width="22px" src="https://raw.githubusercontent.com/peterthehan/peterthehan/master/assets/facebook.svg" />
+  <img align="left" alt="Ali's Facebook" width="22px" src="https://raw.githubusercontent.com/peterthehan/peterthehan/master/assets/facebook.svg" />
 </a>
 <a href="https://open.spotify.com/user/31l2qdzujgpebzpal5z24uue7r2i">
   <img alt="Spotify" width="22px" src="https://raw.githubusercontent.com/peterthehan/peterthehan/master/assets/spotify.svg">


### PR DESCRIPTION
- fixed alt tag for the Facebook link saying Discord.